### PR TITLE
Open tabs on new page on Listings Page #373

### DIFF
--- a/src/components/ListingCard/ListingCard.js
+++ b/src/components/ListingCard/ListingCard.js
@@ -86,6 +86,7 @@ export const ListingCardComponent = props => {
     <NamedLink
       className={classes}
       name="ListingPage"
+      newTab={true}
       params={{ id, slug, rating, ratingArray, mode }}
     >
       <div

--- a/src/components/NamedLink/NamedLink.js
+++ b/src/components/NamedLink/NamedLink.js
@@ -17,15 +17,15 @@
  * will be added to the element className if the current URL matches
  * the one in the generated pathname of the link.
  */
-import React from 'react';
-import PropTypes from 'prop-types';
-import { Link, withRouter } from 'react-router-dom';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
+import React from 'react';
+import { Link, withRouter } from 'react-router-dom';
 import routeConfiguration from '../../routeConfiguration';
 import { pathByRouteName } from '../../util/routes';
 
 export const NamedLinkComponent = props => {
-  const { name, params, title } = props;
+  const { name, params, title, newTab } = props;
 
   // Link props
   const { to, children } = props;
@@ -41,8 +41,10 @@ export const NamedLinkComponent = props => {
     title,
   };
 
+  let linkTarget = newTab ? '_blank' : '_self';
+
   return (
-    <Link to={{ pathname, ...to }} {...aElemProps}>
+    <Link to={{ pathname, ...to }} {...aElemProps} target={linkTarget}>
       {children}
     </Link>
   );


### PR DESCRIPTION
**What has been done**: Changed the NameLink component to accept a newTab option. Listing now open in a new tab.
**Pushed to**: (staging)
**Tag somebody**: @Shane-Walsh 
**PR**: (create a PR if the branch is ready to be merged)

**Asking for validation**: 

- Check on mobile and on a desktop if the issue has been correctly fixed.
- If everything is correct, move the card to the accepted column.
- If the issue isn't fixed, re-open the comment clearly what the problem is and what is the desired result. 
- Move the card to have issues column.
- Merge (or express approval in) the corresponding PR if needed. Move the card to the launch column.